### PR TITLE
add lower, upper, and substring to TapSchema function whitelist

### DIFF
--- a/cadc-adql/build.gradle
+++ b/cadc-adql/build.gradle
@@ -14,14 +14,14 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '1.1'
+version = '1.1.1'
 
 dependencies {
     compile 'log4j:log4j:1.2.+'
 
     compile 'org.opencadc:cadc-util:1.+'
-    compile 'org.opencadc:cadc-tap-server:[1.1,)'
-    compile 'org.opencadc:cadc-tap-schema:[1.1,)'
+    compile 'org.opencadc:cadc-tap-server:[1.1.1,)'
+    compile 'org.opencadc:cadc-tap-schema:[1.1.1,)'
     compile 'org.opencadc:cadc-jsqlparser-compat:0.6.4'
 
     testCompile 'junit:junit:4.+'

--- a/cadc-adql/build.gradle
+++ b/cadc-adql/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     compile 'log4j:log4j:1.2.+'
 
     compile 'org.opencadc:cadc-util:1.+'
-    compile 'org.opencadc:cadc-tap-server:[1.1.1,)'
+    compile 'org.opencadc:cadc-tap-server:[1.1,)'
     compile 'org.opencadc:cadc-tap-schema:[1.1.1,)'
     compile 'org.opencadc:cadc-jsqlparser-compat:0.6.4'
 

--- a/cadc-adql/src/main/java/ca/nrc/cadc/tap/parser/schema/TapSchemaColumnValidator.java
+++ b/cadc-adql/src/main/java/ca/nrc/cadc/tap/parser/schema/TapSchemaColumnValidator.java
@@ -135,7 +135,8 @@ public class TapSchemaColumnValidator extends ReferenceNavigator
         VisitingPart visiting = selectNavigator.getVisitingPart();
         log.debug("visiting is:" + visiting);
         if (visiting.equals(VisitingPart.SELECT_ITEM) || visiting.equals(VisitingPart.FROM)
-                || visiting.equals(VisitingPart.GROUP_BY))
+                //|| visiting.equals(VisitingPart.GROUP_BY)
+                )
         {
             // cannot be by alias
             // possible forms: columnName, table.columnName, tableAilas.columnName, or schema.table.ColumnName

--- a/cadc-tap-schema/build.gradle
+++ b/cadc-tap-schema/build.gradle
@@ -14,7 +14,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '1.1'
+version = '1.1.1'
 
 dependencies {
     compile 'log4j:log4j:1.2.+'

--- a/cadc-tap-schema/src/main/java/ca/nrc/cadc/tap/schema/TapSchemaDAO.java
+++ b/cadc-tap-schema/src/main/java/ca/nrc/cadc/tap/schema/TapSchemaDAO.java
@@ -678,13 +678,13 @@ public class TapSchemaDAO
         // SQL String functions.
 //        functionDescs.add(new FunctionDesc("BIT_LENGTH", "", "adql:INTEGER"));
 //        functionDescs.add(new FunctionDesc("CHARACTER_LENGTH", "", "adql:INTEGER"));
-//        functionDescs.add(new FunctionDesc("LOWER", "", "adql:VARCHAR"));
+        functionDescs.add(new FunctionDesc("LOWER", new TapDataType("char", "*", null)));
 //        functionDescs.add(new FunctionDesc("OCTET_LENGTH", "", "adql:INTEGER"));
 //        functionDescs.add(new FunctionDesc("OVERLAY", "", "adql:VARCHAR")); //SQL92???
 //        functionDescs.add(new FunctionDesc("POSITION", "", "adql:INTEGER"));
-//        functionDescs.add(new FunctionDesc("SUBSTRING", "", "adql:VARCHAR"));
-//        functionDescs.add(new FunctionDesc("TRIM", "", "adql:VARCHAR"));
-//        functionDescs.add(new FunctionDesc("UPPER", "", "adql:VARCHAR"));
+        functionDescs.add(new FunctionDesc("SUBSTRING", new TapDataType("char", "*", null)));
+//        functionDescs.add(new FunctionDesc("TRIM", new TapDataType("char", "*", null)));
+        functionDescs.add(new FunctionDesc("UPPER", new TapDataType("char", "*", null)));
 
         // SQL Date functions.
 //        functionDescs.add(new FunctionDesc("CURRENT_DATE", "", "adql:TIMESTAMP"));

--- a/cadc-tap-server/build.gradle
+++ b/cadc-tap-server/build.gradle
@@ -25,7 +25,7 @@ dependencies {
 
     compile 'org.opencadc:cadc-util:1.+'
     compile 'org.opencadc:cadc-log:1.+'
-    compile 'org.opencadc:cadc-tap-schema:[1.1,)'
+    compile 'org.opencadc:cadc-tap-schema:[1.1.1,)'
     compile 'org.opencadc:cadc-vosi:1.+'
     compile 'org.opencadc:cadc-dali:[1.1,)'
     compile 'org.opencadc:cadc-registry:1.+'


### PR DESCRIPTION
+ fix bug where column alias was not recognised in the group by clause