### PR TITLE
[DM-16711] Remove AutoCommit calls on connection.

### DIFF
--- a/cadc-tap-server/src/main/java/ca/nrc/cadc/tap/QueryRunner.java
+++ b/cadc-tap-server/src/main/java/ca/nrc/cadc/tap/QueryRunner.java
@@ -363,10 +363,9 @@ public class QueryRunner implements JobRunner
                     t2 = System.currentTimeMillis(); dt = t2 - t1; t1 = t2;
                     diagnostics.add(new Result("diag", URI.create("jndi:connect:"+dt)));
 
-                    // manually control transaction, make fetch size (client batch size) small,
+                    // make fetch size (client batch size) small,
                     // and restrict to forward only so that client memory usage is minimal since
                     // we are only interested in reading the ResultSet once
-                    connection.setAutoCommit(false);
                     pstmt = connection.prepareStatement(sql);
                     pstmt.setFetchSize(1000);
                     pstmt.setFetchDirection(ResultSet.FETCH_FORWARD);
@@ -431,11 +430,6 @@ public class QueryRunner implements JobRunner
             {
                 if (connection != null)
                 {
-                    try
-                    {
-                        connection.setAutoCommit(true);
-                    }
-                    catch(Throwable ignore) { }
                     try
                     {
                         resultSet.close();


### PR DESCRIPTION
This caused a small problem with the presto database,
as transactions were left hanging open (and timing out).

After consutlation with Patrick, it seems like playing
with autocommit like this might be unnecessary, and per
my local testing, this has resolved my issue and I don't
see any side effects.