### PR TITLE
replaced javacsv library with commons-csv 

### DIFF
--- a/cadc-tap-schema/build.gradle
+++ b/cadc-tap-schema/build.gradle
@@ -16,13 +16,14 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '1.1.11'
+version = '1.1.12'
 
 dependencies {
     compile 'log4j:log4j:1.2.+'
     compile 'org.jdom:jdom2:2.+'
     compile 'org.springframework:spring-jdbc:2.5.6.SEC01'
     compile 'javax.servlet:javax.servlet-api:3.+'
+    compile 'org.apache.commons:commons-csv:[1.6,1.7)'
 
     compile 'org.opencadc:cadc-util:[1.2.4,)'
     compile 'org.opencadc:cadc-log:1.+'
@@ -30,7 +31,7 @@ dependencies {
     compile 'org.opencadc:cadc-uws:[1.0,)'
     compile 'org.opencadc:cadc-uws-server:[1.1,)'
     compile 'org.opencadc:cadc-dali:[1.1,)'
-    compile 'org.opencadc:cadc-rest:[1.2.2,)'
+    compile 'org.opencadc:cadc-rest:[1.2.6,)'
     compile 'org.opencadc:cadc-access-control:[1.1.13,)'
     compile 'uk.ac.starlink:jcdf:1.2.3'
     compile 'uk.ac.starlink:stil-io:3.3.2'

--- a/cadc-tap-schema/src/main/java/ca/nrc/cadc/vosi/actions/TableContentHandler.java
+++ b/cadc-tap-schema/src/main/java/ca/nrc/cadc/vosi/actions/TableContentHandler.java
@@ -67,44 +67,54 @@
 
 package ca.nrc.cadc.vosi.actions;
 
-import java.io.IOException;
-import java.io.InputStream;
-
-import org.apache.log4j.Logger;
-
-import ca.nrc.cadc.dali.tables.TableData;
+import ca.nrc.cadc.net.ResourceNotFoundException;
 import ca.nrc.cadc.rest.InlineContentException;
 import ca.nrc.cadc.rest.InlineContentHandler;
 import ca.nrc.cadc.tap.db.AsciiTableData;
 import ca.nrc.cadc.tap.db.FitsTableData;
-import ca.nrc.cadc.tap.db.TableDataStream;
+import ca.nrc.cadc.tap.db.TableDataInputStream;
+import ca.nrc.cadc.tap.db.TableLoader;
+import ca.nrc.cadc.tap.schema.TableDesc;
+import ca.nrc.cadc.tap.schema.TapSchemaDAO;
+import java.io.IOException;
+import java.io.InputStream;
+import org.apache.log4j.Logger;
 
 public class TableContentHandler implements InlineContentHandler {
     
     private static final Logger log = Logger.getLogger(TableContentHandler.class);
     
-    public static final String TABLE_DATA = "tableData";
+    public static final String MSG = "message";
     public static final String CONTENT_TYPE_CSV = "text/csv";
     public static final String CONTENT_TYPE_TSV = "text/tab-separated-values";
     public static final String CONTENT_TYPE_FITS = "application/fits";
-
     
-    static class ContentRef {
-        String contentType;
-        InputStream istream;
-
-        public ContentRef(String contentType, InputStream istream) {
-            this.contentType = contentType;
-            this.istream = istream;
-        }
+    private static final int BATCH_SIZE = 1000;
+    
+    SyncLoadAction parent;
+    
+    TableContentHandler(SyncLoadAction parent) {
+        this.parent = parent;
     }
-    
+
     @Override
     public Content accept(String name, String contentType, InputStream inputStream)
-            throws InlineContentException, IOException {
-        
+            throws InlineContentException, IOException, ResourceNotFoundException {
+        String tableName = parent.getTableName();
+        if (tableName == null) {
+            throw new IllegalArgumentException("Missing table name in path");
+        }
+
+        parent.checkTableWritePermission(tableName);
+
+        TapSchemaDAO ts = parent.getTapSchemaDAO();
+        TableDesc targetTableDesc = ts.getTable(tableName);
+        if (targetTableDesc == null) {
+            throw new ResourceNotFoundException("Table not found: " + tableName);
+        }
+
         log.debug("Content-Type: " + contentType);
-        TableDataStream tableData = null;
+        TableDataInputStream tableData = null;
         if (contentType == null) {
             throw new IllegalArgumentException("Table Content-Type is requried.");
         }
@@ -117,10 +127,15 @@ public class TableContentHandler implements InlineContentHandler {
         if (tableData == null) {       
             throw new IllegalArgumentException("Unsupported table ContentType: " + contentType);
         }
+        
+        TableLoader tl = new TableLoader(parent.getDataSource(), BATCH_SIZE);
+        tl.load(targetTableDesc, tableData);
+
+        String msg = "Inserted " + tl.getTotalInserts() + " rows to table " + tableName;
     
         InlineContentHandler.Content content = new InlineContentHandler.Content();
-        content.name = TABLE_DATA;
-        content.value = tableData;
+        content.name = MSG;
+        content.value = msg;
         
         return content;
     }


### PR DESCRIPTION
because former calls close() in a finalise() method

moved bulk load from SyncLoadAction into the TableContentHandler so it doesn't have to hold a ref to the input stream