### PR TITLE
removed array support from base cadc-tap-schema; defer to backend-specific DataTypeMapper impl

### DIFF
--- a/cadc-tap-schema/build.gradle
+++ b/cadc-tap-schema/build.gradle
@@ -16,7 +16,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '1.1.21'
+version = '1.1.22'
 
 dependencies {
     compile 'log4j:log4j:[1.2,2.0)'

--- a/cadc-tap-schema/src/main/java/ca/nrc/cadc/tap/db/BasicDataTypeMapper.java
+++ b/cadc-tap-schema/src/main/java/ca/nrc/cadc/tap/db/BasicDataTypeMapper.java
@@ -130,12 +130,6 @@ public class BasicDataTypeMapper implements DatabaseDataType {
 
         dataTypes.put(TapDataType.STRING, new TypePair("CHAR", Types.CHAR));
         dataTypes.put(TapDataType.TIMESTAMP, new TypePair("TIMESTAMP", Types.TIMESTAMP));
-        
-        dataTypes.put(TapDataType.SHORT_ARR, new TypePair("SMALLINT", Types.SMALLINT));
-        dataTypes.put(TapDataType.INTEGER_ARR, new TypePair("INTEGER", Types.INTEGER));
-        dataTypes.put(TapDataType.LONG_ARR, new TypePair("BIGINT", Types.BIGINT));
-        dataTypes.put(TapDataType.FLOAT_ARR, new TypePair("REAL", Types.REAL));
-        dataTypes.put(TapDataType.DOUBLE_ARR, new TypePair("DOUBLE PRECISION", Types.DOUBLE));
     }
 
     /**

--- a/cadc-tap-schema/src/main/java/ca/nrc/cadc/tap/schema/TapDataType.java
+++ b/cadc-tap-schema/src/main/java/ca/nrc/cadc/tap/schema/TapDataType.java
@@ -189,11 +189,4 @@ public class TapDataType
     // ADQL types
     public static final TapDataType BLOB = new TapDataType("byte", "*", "blob");
     public static final TapDataType CLOB = new TapDataType("char", "*", "clob");
-    
-    // Primitive arrays
-    public static final TapDataType SHORT_ARR = new TapDataType("short", "*", null);
-    public static final TapDataType INTEGER_ARR = new TapDataType("int", "*", null);
-    public static final TapDataType LONG_ARR = new TapDataType("long", "*", null);
-    public static final TapDataType FLOAT_ARR = new TapDataType("float", "*", null);
-    public static final TapDataType DOUBLE_ARR = new TapDataType("double", "*", null);
 }

--- a/cadc-tap-server-pg/build.gradle
+++ b/cadc-tap-server-pg/build.gradle
@@ -16,11 +16,11 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '1.0.4'
+version = '1.0.5'
 
 dependencies {
     compile 'org.opencadc:cadc-dali-pg:[0.1,)'
-    compile 'org.opencadc:cadc-tap-schema:[1.1.6, )'
+    compile 'org.opencadc:cadc-tap-schema:[1.1.22, )'
     compile 'org.opencadc:cadc-tap-server:[1.1.7, )'
 
     testCompile 'junit:junit:[4.0,5.0)'


### PR DESCRIPTION
This correctly enables arrays in postgresql but not by default