### PR TITLE
TapClient API: added queryForObject, renamed execute to query

### DIFF
--- a/cadc-tap/build.gradle
+++ b/cadc-tap/build.gradle
@@ -16,7 +16,7 @@ apply from: '../opencadc.gradle'
 sourceCompatibility = 1.8
 
 group = 'org.opencadc'
-version = '1.1.3'
+version = '1.1.4'
 
 description = 'OpenCADC TAP-1.1 tap client library'
 def git_url = 'https://github.com/opencadc/tap'

--- a/cadc-tap/src/main/java/org/opencadc/tap/TableDataIterator.java
+++ b/cadc-tap/src/main/java/org/opencadc/tap/TableDataIterator.java
@@ -1,0 +1,106 @@
+/*
+************************************************************************
+*******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
+**************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
+*
+*  (c) 2021.                            (c) 2021.
+*  Government of Canada                 Gouvernement du Canada
+*  National Research Council            Conseil national de recherches
+*  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+*  All rights reserved                  Tous droits réservés
+*
+*  NRC disclaims any warranties,        Le CNRC dénie toute garantie
+*  expressed, implied, or               énoncée, implicite ou légale,
+*  statutory, of any kind with          de quelque nature que ce
+*  respect to the software,             soit, concernant le logiciel,
+*  including without limitation         y compris sans restriction
+*  any warranty of merchantability      toute garantie de valeur
+*  or fitness for a particular          marchande ou de pertinence
+*  purpose. NRC shall not be            pour un usage particulier.
+*  liable in any event for any          Le CNRC ne pourra en aucun cas
+*  damages, whether direct or           être tenu responsable de tout
+*  indirect, special or general,        dommage, direct ou indirect,
+*  consequential or incidental,         particulier ou général,
+*  arising from the use of the          accessoire ou fortuit, résultant
+*  software.  Neither the name          de l'utilisation du logiciel. Ni
+*  of the National Research             le nom du Conseil National de
+*  Council of Canada nor the            Recherches du Canada ni les noms
+*  names of its contributors may        de ses  participants ne peuvent
+*  be used to endorse or promote        être utilisés pour approuver ou
+*  products derived from this           promouvoir les produits dérivés
+*  software without specific prior      de ce logiciel sans autorisation
+*  written permission.                  préalable et particulière
+*                                       par écrit.
+*
+*  This file is part of the             Ce fichier fait partie du projet
+*  OpenCADC project.                    OpenCADC.
+*
+*  OpenCADC is free software:           OpenCADC est un logiciel libre ;
+*  you can redistribute it and/or       vous pouvez le redistribuer ou le
+*  modify it under the terms of         modifier suivant les termes de
+*  the GNU Affero General Public        la “GNU Affero General Public
+*  License as published by the          License” telle que publiée
+*  Free Software Foundation,            par la Free Software Foundation
+*  either version 3 of the              : soit la version 3 de cette
+*  License, or (at your option)         licence, soit (à votre gré)
+*  any later version.                   toute version ultérieure.
+*
+*  OpenCADC is distributed in the       OpenCADC est distribué
+*  hope that it will be useful,         dans l’espoir qu’il vous
+*  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
+*  without even the implied             GARANTIE : sans même la garantie
+*  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
+*  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
+*  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
+*  General Public License for           Générale Publique GNU Affero
+*  more details.                        pour plus de détails.
+*
+*  You should have received             Vous devriez avoir reçu une
+*  a copy of the GNU Affero             copie de la Licence Générale
+*  General Public License along         Publique GNU Affero avec
+*  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
+*  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
+*                                       <http://www.gnu.org/licenses/>.
+*
+************************************************************************
+*/
+
+package org.opencadc.tap;
+
+import ca.nrc.cadc.io.ResourceIterator;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+import org.apache.log4j.Logger;
+
+/**
+ * An iterator wrapper that implements ResourceIterator as well.
+ * 
+ * @author pdowler
+ */
+public class TableDataIterator<E> implements ResourceIterator<E> {
+    private static final Logger log = Logger.getLogger(TableDataIterator.class);
+    
+    private final TapRowMapper<E> mapper;
+    private final Iterator<List<Object>> rows;
+
+    public TableDataIterator(TapRowMapper<E> mapper, Iterator<List<Object>> rows) { 
+        this.mapper = mapper;
+        this.rows = rows;
+    }
+    
+    @Override
+    public boolean hasNext() {
+        return rows.hasNext();
+    }
+
+    @Override
+    public E next() {
+        return mapper.mapRow(rows.next());
+    }
+
+    @Override
+    public void close() throws IOException {
+        // no-op
+    }
+}


### PR DESCRIPTION
streaming query optimization: set small MAXREC in meta query to avoid second request if result is small enough to fit