### PR TITLE
Oracle contains fix

### DIFF
--- a/cadc-tap-server-oracle/CHANGELOG.md
+++ b/cadc-tap-server-oracle/CHANGELOG.md
@@ -1,5 +1,9 @@
 # cadc-tap-server-oracle
 
+## 2022.05.20 - 1.2.9
+
+  * Use proper Oracle functions for indexed columns with respect to `CONTAINS` or `INSIDE` operations. 
+
 ## 2019.10.18 - 1.2.4
 
   * Removed too-specific code for column replacement.

--- a/cadc-tap-server-oracle/README.md
+++ b/cadc-tap-server-oracle/README.md
@@ -1,8 +1,8 @@
-# cadc-tap-server-oracle 1.2.4
+# cadc-tap-server-oracle 1.2.9
 
 Offers Oracle support to handle datatype conversions in ADQL.
 
-ALMA currently has a [sample implementation](https://github.com/opencadc/alma/tree/master/obscore).
+ALMA currently has a [sample implementation](https://github.com/opencadc/alma/tree/master/tap).
 
 ## Requirements
 

--- a/cadc-tap-server-oracle/build.gradle
+++ b/cadc-tap-server-oracle/build.gradle
@@ -13,17 +13,17 @@ repositories {
 apply from: '../opencadc.gradle'
 sourceCompatibility = 1.8
 group = 'org.opencadc'
-version = '1.2.7'
+version = '1.2.8'
 
 description = 'OpenCADC TAP-1.1 tap server plugin (Oracle)'
 def git_url = 'https://github.com/opencadc/tap'
 
 dependencies {
-    implementation 'org.opencadc:cadc-tap-server:[1.1.5, )'
+    implementation 'org.opencadc:cadc-tap-server:[1.1.17, )'
     implementation 'org.opencadc:cadc-adql:[1.1.4, )'
 
-    testImplementation 'junit:junit:[4.12,)'
-    testImplementation 'org.opencadc:cadc-util:[1.2,)'
+    testImplementation 'junit:junit:[4.12,5.0)'
+    testImplementation 'org.opencadc:cadc-util:[1.5.11,)'
     testImplementation 'xerces:xercesImpl:[2.12,)'
     testImplementation 'org.jdom:jaxen-jdom:1.0-FCS'
 }

--- a/cadc-tap-server-oracle/build.gradle
+++ b/cadc-tap-server-oracle/build.gradle
@@ -13,17 +13,17 @@ repositories {
 apply from: '../opencadc.gradle'
 sourceCompatibility = 1.8
 group = 'org.opencadc'
-version = '1.2.8'
+version = '1.2.9'
 
 description = 'OpenCADC TAP-1.1 tap server plugin (Oracle)'
 def git_url = 'https://github.com/opencadc/tap'
 
 dependencies {
-    implementation 'org.opencadc:cadc-tap-server:[1.1.17, )'
-    implementation 'org.opencadc:cadc-adql:[1.1.4, )'
+    implementation 'org.opencadc:cadc-tap-server:[1.1.19,2.0)'
+    implementation 'org.opencadc:cadc-adql:[1.1.11,2.0)'
 
     testImplementation 'junit:junit:[4.12,5.0)'
-    testImplementation 'org.opencadc:cadc-util:[1.5.11,)'
+    testImplementation 'org.opencadc:cadc-util:[1.6.0,2.0)'
     testImplementation 'xerces:xercesImpl:[2.12,)'
     testImplementation 'org.jdom:jaxen-jdom:1.0-FCS'
 }

--- a/cadc-tap-server-oracle/src/test/java/ca/nrc/cadc/tap/parser/converter/OracleRegionConverterTest.java
+++ b/cadc-tap-server-oracle/src/test/java/ca/nrc/cadc/tap/parser/converter/OracleRegionConverterTest.java
@@ -109,9 +109,9 @@ public class OracleRegionConverterTest {
 
         final String resultFunctionSource = resultFunction.toString();
         Assert.assertEquals("Wrong output.",
-                            "SDO_GEOM.RELATE(SDO_UTIL.CIRCLE_POLYGON(88.0, 12.0, "
-                            + 0.8D * OracleCircle.TO_METRES_ON_EARTH + ", 0.005), 'contains', " +
-                            "SDO_GEOMETRY(2001, 8307, SDO_POINT_TYPE(16.8, 33.4, NULL), NULL, NULL), 0.005)",
+                            "SDO_CONTAINS(SDO_UTIL.CIRCLE_POLYGON(88.0, 12.0, "
+                            + 0.8D * OracleCircle.TO_METRES_ON_EARTH + ", 0.005), " +
+                            "SDO_GEOMETRY(2001, 8307, SDO_POINT_TYPE(16.8, 33.4, NULL), NULL, NULL))",
                             resultFunctionSource);
     }
 
@@ -140,10 +140,10 @@ public class OracleRegionConverterTest {
 
         final String resultFunctionSource = equalsFunction.toString();
         Assert.assertEquals("Wrong output.",
-                            "SDO_GEOM.RELATE(SDO_UTIL.CIRCLE_POLYGON(88.0, 12.0, "
-                            + 0.8D * OracleCircle.TO_METRES_ON_EARTH + ", 0.005), 'contains', " +
+                            "SDO_CONTAINS(SDO_UTIL.CIRCLE_POLYGON(88.0, 12.0, "
+                            + 0.8D * OracleCircle.TO_METRES_ON_EARTH + ", 0.005), " +
                             "SDO_GEOMETRY"
-                            + "(2001, 8307, SDO_POINT_TYPE(16.8, 33.4, NULL), NULL, NULL), 0.005) = 'CONTAINS'",
+                            + "(2001, 8307, SDO_POINT_TYPE(16.8, 33.4, NULL), NULL, NULL)) = 'TRUE'",
                             resultFunctionSource);
     }
 

--- a/cadc-tap-server-oracle/src/test/java/ca/nrc/cadc/tap/parser/converter/OracleRegionConverterTest.java
+++ b/cadc-tap-server-oracle/src/test/java/ca/nrc/cadc/tap/parser/converter/OracleRegionConverterTest.java
@@ -166,6 +166,24 @@ public class OracleRegionConverterTest {
     }
 
     @Test
+    public void handleColumnReferenceInside() {
+        final OracleRegionConverter oracleRegionConverter = new OracleRegionConverter(new ExpressionNavigator(),
+                                                                                      new ReferenceNavigator(),
+                                                                                      new FromItemNavigator());
+
+        final Expression left = new Column(new Table(), "s_region");
+        final Expression right = new OraclePoint(new Point(14.0D, -2.0D));
+        final Expression distanceFunction = oracleRegionConverter.handleContains(left, right);
+
+        assert distanceFunction instanceof Function;
+
+        Assert.assertEquals("Wrong SQL DISTANCE output.",
+                            "SDO_INSIDE(s_region, " +
+                            "SDO_GEOMETRY(2001, 8307, SDO_POINT_TYPE(14.0, -2.0, NULL), NULL, NULL))",
+                            distanceFunction.toString());
+    }
+
+    @Test
     public void handleColumnReference() {
         final OracleRegionConverter oracleRegionConverter = new OracleRegionConverter(new ExpressionNavigator(),
                                                                                       new ReferenceNavigator(),


### PR DESCRIPTION
Oracle SDO_GEOM API dictates that the first argument is the indexed column, which means using the proper functions.  This fix is to properly add `SDO_CONTAINS` and `SDO_INSIDE` where appropriate for performance.