### PR TITLE
cadc-tap-tmp and cadc-tap-server: more configurable at runtime

### DIFF
--- a/cadc-tap-server/build.gradle
+++ b/cadc-tap-server/build.gradle
@@ -13,7 +13,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '1.1.21'
+version = '1.1.22'
 
 description = 'OpenCADC TAP-1.1 tap server library'
 def git_url = 'https://github.com/opencadc/tap'

--- a/cadc-tap-tmp/README.md
+++ b/cadc-tap-tmp/README.md
@@ -2,19 +2,26 @@
 
 Simple library to provide plugins that implement both the ResultStore (TAP-async 
 result storage) and UWSInlineContentHandler (inline TAP_UPLOAD support) interfaces. 
-Two interfaces are provided: `org.opencadc.tap.tmp.TempStorageManager` uses a configurable
+Two implementations are provided: `org.opencadc.tap.tmp.TempStorageManager` uses a configurable
 local directory in the filesystem, `org.opencadc.tap.tmp.HttpStorageManager` uses an 
 external HTTP service to store and deliver files.
 
-## Applying cadc-tap-tmp
+In addition, a third implementation `org.opencadc.tap.tmp.DelegatingStorageManager` can be
+configured in services; this implementation can be configured to load and use one of the
+other two classes above.
 
-### Configuration
-A configuration file `cadc-tap-tmp.properties` needs to be accessible in the `System.getProperty("user.home")/config` folder, or in a separate folder specified by a System property called `ca.nrc.cadc.util.PropertiesReader.dir`.
+## configuration
+
+### cadc-tap-tmp.properties
+This configuration file needs to be accessible in the `System.getProperty("user.home")/config` folder.
 
 For the local filesystem using `TempStorageManager`:
 ```properties
-org.opencadc.tap.tmp.TempStorageManager.baseURL = {base URL for result files}
+# specify implementation in case the DelegatingStorageManager is used
+org.opencadc.tap.tmp.StorageManager = org.opencadc.tap.tmp.TempStorageManager
 
+# TempStorageManager config
+org.opencadc.tap.tmp.TempStorageManager.baseURL = {base URL for result files}
 org.opencadc.tap.tmp.TempStorageManager.baseStorageDir = {local directory for tmp files}
 ```
 For the TempStorageManager, an additional servlet must be deployed in the TAP 
@@ -22,8 +29,11 @@ service to [Enable Retrieval](#enable-retrieval)
 
 For the external http service using `HttpStorageManager`:
 ```properties
-org.opencadc.tap.tmp.HttpStorageManager.baseURL = {base URL for result files}
+# specify implementation in case the DelegatingStorageManager is used
+org.opencadc.tap.tmp.StorageManager = org.opencadc.tap.tmp.HttpStorageManager
 
+# HttpStorageManager config
+org.opencadc.tap.tmp.HttpStorageManager.baseURL = {base URL for result files}
 org.opencadc.tap.tmp.HttpStorageManager.certificate = {certificate file name}
 ```
 For the HttpStorageManager, the result will be PUT to that same URL and requires 

--- a/cadc-tap-tmp/build.gradle
+++ b/cadc-tap-tmp/build.gradle
@@ -15,7 +15,7 @@ apply from: '../opencadc.gradle'
 sourceCompatibility = 1.8
 
 group = 'org.opencadc'
-version = '1.1.1'
+version = '1.1.2'
 
 description = 'OpenCADC TAP-1.1 temporary on-disk upload storage library'
 def git_url = 'https://github.com/opencadc/tap'

--- a/cadc-tap-tmp/src/main/java/org/opencadc/tap/tmp/DelegatingStorageManager.java
+++ b/cadc-tap-tmp/src/main/java/org/opencadc/tap/tmp/DelegatingStorageManager.java
@@ -3,7 +3,7 @@
 *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
 *
-*  (c) 2023.                            (c) 2023.
+*  (c) 2022.                            (c) 2022.
 *  Government of Canada                 Gouvernement du Canada
 *  National Research Council            Conseil national de recherches
 *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
@@ -67,70 +67,83 @@
 
 package org.opencadc.tap.tmp;
 
-import ca.nrc.cadc.rest.InitAction;
+import ca.nrc.cadc.dali.tables.TableWriter;
+import ca.nrc.cadc.net.ResourceNotFoundException;
+import ca.nrc.cadc.net.TransientException;
+import ca.nrc.cadc.rest.InlineContentException;
+import ca.nrc.cadc.util.InvalidConfigException;
 import ca.nrc.cadc.util.MultiValuedProperties;
 import ca.nrc.cadc.util.PropertiesReader;
-import java.io.File;
+import ca.nrc.cadc.uws.Job;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.sql.ResultSet;
 import org.apache.log4j.Logger;
 
 /**
- *
+ * StorageManager implementation that delegates to a configured implementation at
+ * runtime.
+ * 
  * @author pdowler
  */
-public class TempStorageInitAction extends InitAction {
-    private static final Logger log = Logger.getLogger(TempStorageInitAction.class);
-
-    static final String CONFIG = "cadc-tap-tmp.properties";
+public class DelegatingStorageManager implements StorageManager {
+    private static final Logger log = Logger.getLogger(DelegatingStorageManager.class);
 
     private static final String IMPL_KEY = StorageManager.class.getName();
-    private static final String CONFIG_KEY = TempStorageManager.class.getName();
     
-    static final String BASE_DIR_KEY = CONFIG_KEY + ".baseStorageDir";
-    static final String BASE_URL_KEY = CONFIG_KEY + ".baseURL";
+    private final StorageManager impl;
     
-    public TempStorageInitAction() { 
+    public DelegatingStorageManager() {
+        PropertiesReader r = new PropertiesReader(CONFIG);
+        MultiValuedProperties props = r.getAllProperties();
+        String cname = props.getFirstPropertyValue(IMPL_KEY);
+        if (cname == null) {
+            throw new InvalidConfigException("missing required key: " + IMPL_KEY);
+        }
+        try {
+            Class c = Class.forName(cname);
+            this.impl = (StorageManager) c.newInstance();
+        } catch (ClassNotFoundException | IllegalAccessException | InstantiationException ex) {
+            throw new InvalidConfigException("failed to load StorageManager impl: " + cname, ex);
+        }
     }
 
     @Override
-    public void doInit() {
-        // verify
-        getConfig();
+    public void setJob(Job job) {
+        impl.setJob(job);
+    }
+
+    @Override
+    public URL put(ResultSet rs, TableWriter<ResultSet> writer) throws IOException {
+        return impl.put(rs, writer);
+    }
+
+    @Override
+    public URL put(ResultSet rs, TableWriter<ResultSet> writer, Integer maxrec) throws IOException {
+        return impl.put(rs, writer, maxrec);
+    }
+
+    @Override
+    public URL put(Throwable t, TableWriter writer) throws IOException {
+        return impl.put(t, writer);
+    }
+
+    @Override
+    public void setContentType(String contentType) {
+        impl.setContentType(contentType);
+    }
+
+    @Override
+    public void setFilename(String filename) {
+        impl.setFilename(filename);
+    }
+
+    @Override
+    public Content accept(String name, String contentType, InputStream inputStream) 
+            throws InlineContentException, IOException, ResourceNotFoundException, TransientException {
+        return impl.accept(name, contentType, inputStream);
     }
     
-    static MultiValuedProperties getConfig() {
-        PropertiesReader r = new PropertiesReader(CONFIG);
-        MultiValuedProperties props = r.getAllProperties();
-
-        for (String s : props.keySet()) {
-            log.debug("props: " + s + "=" + props.getProperty(s));
-        }
-        
-        String implClass = props.getFirstPropertyValue(IMPL_KEY);
-        log.debug(CONFIG + ":  " + IMPL_KEY + " = " + implClass);
-        if (implClass == null || implClass.equals(CONFIG_KEY)) {
-            // init config
-            final String baseURL = props.getFirstPropertyValue(BASE_URL_KEY);
-            final File baseDir = new File(props.getFirstPropertyValue(BASE_DIR_KEY));
-
-            if (!baseDir.exists()) {
-                baseDir.mkdirs();
-            }
-            if (!baseDir.exists()) {
-                throw new RuntimeException(BASE_DIR_KEY + "=" + baseDir + " does not exist, cannot create");
-            }
-            if (!baseDir.isDirectory()) {
-                throw new RuntimeException(BASE_DIR_KEY + "=" + baseDir + " is not a directory");
-            }
-            if (!baseDir.canRead() || !baseDir.canWrite()) {
-                throw new RuntimeException(BASE_DIR_KEY + "=" + baseDir + " is not readable && writable");
-            }
-
-            if (baseURL == null) {
-                log.error("CONFIG: incomplete: baseDir=" + baseDir + "  baseURL=" + baseURL);
-                throw new RuntimeException("CONFIG incomplete: baseDir=" + baseDir + " baseURL=" + baseURL);
-            }
-        }
-
-        return props;
-    }
+    
 }

--- a/cadc-tap-tmp/src/main/java/org/opencadc/tap/tmp/HttpStorageManager.java
+++ b/cadc-tap-tmp/src/main/java/org/opencadc/tap/tmp/HttpStorageManager.java
@@ -68,7 +68,6 @@
 package org.opencadc.tap.tmp;
 
 import ca.nrc.cadc.auth.AuthMethod;
-import ca.nrc.cadc.auth.AuthenticationUtil;
 import ca.nrc.cadc.auth.RunnableAction;
 import ca.nrc.cadc.auth.SSLUtil;
 import ca.nrc.cadc.cred.client.CredUtil;
@@ -84,7 +83,6 @@ import ca.nrc.cadc.net.TransientException;
 import ca.nrc.cadc.reg.Standards;
 import ca.nrc.cadc.reg.client.RegistryClient;
 import ca.nrc.cadc.rest.InlineContentException;
-import ca.nrc.cadc.tap.ResultStore;
 import ca.nrc.cadc.util.InvalidConfigException;
 import ca.nrc.cadc.util.MultiValuedProperties;
 import ca.nrc.cadc.util.PropertiesReader;
@@ -122,24 +120,30 @@ import org.apache.log4j.Logger;
  * 
  * @author pdowler
  */
-public class HttpStorageManager implements ResultStore, UWSInlineContentHandler {
+public class HttpStorageManager implements StorageManager {
     private static final Logger log = Logger.getLogger(HttpStorageManager.class);
 
-    private static final String CONFIG = "cadc-tap-tmp.properties";
     private static final String BASE_URL_KEY = HttpStorageManager.class.getName() + ".baseURL";
     private static final String CERT_KEY = HttpStorageManager.class.getName() + ".certificate";
     
     private Job job;
-    
     private String contentType;
     private String  filename;
-    
-    private final URL baseURL;
-    private final File certFile;
+    private URL baseURL;
+    private File certFile;
     
     public HttpStorageManager() throws InvalidConfigException {
         PropertiesReader r = new PropertiesReader(CONFIG);
         MultiValuedProperties props = r.getAllProperties();
+        init(props);
+    }
+
+    // constructed by DelegatingStorageManager
+    HttpStorageManager(MultiValuedProperties props) {
+        init(props);
+    }
+    
+    private void init(MultiValuedProperties props) {
         String surl = props.getFirstPropertyValue(BASE_URL_KEY);
         try {
             this.baseURL = new URL(surl);
@@ -151,6 +155,7 @@ public class HttpStorageManager implements ResultStore, UWSInlineContentHandler 
         log.debug("cert file: " + absCertFile);
         this.certFile = new File(absCertFile);
     }
+    
 
     @Override
     public void setJob(Job job) {

--- a/cadc-tap-tmp/src/main/java/org/opencadc/tap/tmp/StorageManager.java
+++ b/cadc-tap-tmp/src/main/java/org/opencadc/tap/tmp/StorageManager.java
@@ -3,7 +3,7 @@
 *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
 *
-*  (c) 2023.                            (c) 2023.
+*  (c) 2022.                            (c) 2022.
 *  Government of Canada                 Gouvernement du Canada
 *  National Research Council            Conseil national de recherches
 *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
@@ -67,70 +67,14 @@
 
 package org.opencadc.tap.tmp;
 
-import ca.nrc.cadc.rest.InitAction;
-import ca.nrc.cadc.util.MultiValuedProperties;
-import ca.nrc.cadc.util.PropertiesReader;
-import java.io.File;
-import org.apache.log4j.Logger;
+import ca.nrc.cadc.tap.ResultStore;
+import ca.nrc.cadc.uws.web.UWSInlineContentHandler;
 
 /**
- *
+ * Interface for storage manager implementations.
+ * 
  * @author pdowler
  */
-public class TempStorageInitAction extends InitAction {
-    private static final Logger log = Logger.getLogger(TempStorageInitAction.class);
-
+public interface StorageManager extends ResultStore, UWSInlineContentHandler {
     static final String CONFIG = "cadc-tap-tmp.properties";
-
-    private static final String IMPL_KEY = StorageManager.class.getName();
-    private static final String CONFIG_KEY = TempStorageManager.class.getName();
-    
-    static final String BASE_DIR_KEY = CONFIG_KEY + ".baseStorageDir";
-    static final String BASE_URL_KEY = CONFIG_KEY + ".baseURL";
-    
-    public TempStorageInitAction() { 
-    }
-
-    @Override
-    public void doInit() {
-        // verify
-        getConfig();
-    }
-    
-    static MultiValuedProperties getConfig() {
-        PropertiesReader r = new PropertiesReader(CONFIG);
-        MultiValuedProperties props = r.getAllProperties();
-
-        for (String s : props.keySet()) {
-            log.debug("props: " + s + "=" + props.getProperty(s));
-        }
-        
-        String implClass = props.getFirstPropertyValue(IMPL_KEY);
-        log.debug(CONFIG + ":  " + IMPL_KEY + " = " + implClass);
-        if (implClass == null || implClass.equals(CONFIG_KEY)) {
-            // init config
-            final String baseURL = props.getFirstPropertyValue(BASE_URL_KEY);
-            final File baseDir = new File(props.getFirstPropertyValue(BASE_DIR_KEY));
-
-            if (!baseDir.exists()) {
-                baseDir.mkdirs();
-            }
-            if (!baseDir.exists()) {
-                throw new RuntimeException(BASE_DIR_KEY + "=" + baseDir + " does not exist, cannot create");
-            }
-            if (!baseDir.isDirectory()) {
-                throw new RuntimeException(BASE_DIR_KEY + "=" + baseDir + " is not a directory");
-            }
-            if (!baseDir.canRead() || !baseDir.canWrite()) {
-                throw new RuntimeException(BASE_DIR_KEY + "=" + baseDir + " is not readable && writable");
-            }
-
-            if (baseURL == null) {
-                log.error("CONFIG: incomplete: baseDir=" + baseDir + "  baseURL=" + baseURL);
-                throw new RuntimeException("CONFIG incomplete: baseDir=" + baseDir + " baseURL=" + baseURL);
-            }
-        }
-
-        return props;
-    }
 }

--- a/cadc-tap-tmp/src/main/java/org/opencadc/tap/tmp/TempStorageManager.java
+++ b/cadc-tap-tmp/src/main/java/org/opencadc/tap/tmp/TempStorageManager.java
@@ -94,7 +94,7 @@ import org.apache.log4j.Logger;
  *
  * @author pdowler
  */
-public class TempStorageManager implements ResultStore, UWSInlineContentHandler {
+public class TempStorageManager implements StorageManager {
 
     private static final Logger log = Logger.getLogger(TempStorageManager.class);
 
@@ -107,6 +107,12 @@ public class TempStorageManager implements ResultStore, UWSInlineContentHandler 
 
     public TempStorageManager() {
         MultiValuedProperties props = TempStorageInitAction.getConfig();
+        this.baseURL = props.getFirstPropertyValue(TempStorageInitAction.BASE_URL_KEY);
+        this.baseDir = new File(props.getFirstPropertyValue(TempStorageInitAction.BASE_DIR_KEY));
+    }
+    
+    // constructed by DelegatingStorageManager
+    TempStorageManager(MultiValuedProperties props) {
         this.baseURL = props.getFirstPropertyValue(TempStorageInitAction.BASE_URL_KEY);
         this.baseDir = new File(props.getFirstPropertyValue(TempStorageInitAction.BASE_DIR_KEY));
     }


### PR DESCRIPTION
covers: ResultStore and UWSInlineContentHandler via cadc-tap-tmp

covers: inject datalink service descriptors from config dir before classpath