### PR TITLE
retroactively fix the tap_schema-1.1.x to 1.2.0 upgrade

### DIFF
--- a/cadc-tap-schema/src/main/resources/postgresql/tap_schema.upgrade-1.2.0.sql
+++ b/cadc-tap-schema/src/main/resources/postgresql/tap_schema.upgrade-1.2.0.sql
@@ -14,3 +14,11 @@ alter table tap_schema.tables11
     add column read_anon        integer,
     add column read_only_group  varchar(128),
     add column read_write_group varchar(128);
+
+-- this was missing from here when this was the current version, 
+-- but it was in the 1.2.0 create script
+alter table tap_schema.columns11
+    add column owner_id         varchar(32),
+    add column read_anon        integer,
+    add column read_only_group  varchar(128),
+    add column read_write_group varchar(128);


### PR DESCRIPTION
adding to tap_schema.columns was missing