### PR TITLE
modify upload table transient fields to use TableDesc.TableLocationInfo

### DIFF
--- a/cadc-tap-server/src/main/java/ca/nrc/cadc/tap/BasicUploadManager.java
+++ b/cadc-tap-server/src/main/java/ca/nrc/cadc/tap/BasicUploadManager.java
@@ -94,6 +94,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 import javax.sql.DataSource;
 import org.apache.log4j.Logger;
 import org.opencadc.tap.io.TableDataInputStream;

--- a/cadc-tap-server/src/main/java/ca/nrc/cadc/tap/QueryRunner.java
+++ b/cadc-tap-server/src/main/java/ca/nrc/cadc/tap/QueryRunner.java
@@ -138,7 +138,7 @@ public class QueryRunner implements JobRunner {
     private WebServiceLogInfo logInfo;
     
     // intermediate state for the UWS JobExecutor to access when job is HELD
-    public final transient Map<String,URI> uploadTableLocations = new TreeMap<>();
+    public final transient Map<String,TableDesc.TableLocationInfo> uploadTableLocations = new TreeMap<>();
     public transient List<TapSelectItem> selectList;
     public transient VOTableDocument resultTemplate;
     public transient String internalSQL;
@@ -308,7 +308,7 @@ public class QueryRunner implements JobRunner {
 
                 for (Map.Entry<String, TableDesc> e : tableDescs.entrySet()) {
                     if (e.getValue().dataLocation != null) {
-                        uploadTableLocations.put(e.getValue().getTableName(), e.getValue().dataLocation);
+                        uploadTableLocations.put(e.getKey(), e.getValue().dataLocation);
                     }
                 }
             }
@@ -587,8 +587,13 @@ public class QueryRunner implements JobRunner {
                 log.warn("job " + job.getID() + " DONE");
                 if (uploadTableLocations != null) {
                     log.warn("stored upload tables: " + uploadTableLocations.size());
-                    for (Map.Entry<String,URI> e : uploadTableLocations.entrySet()) {
-                        log.warn("  upload: " + e.getKey() + " at " + e.getValue());
+                    for (Map.Entry<String,TableDesc.TableLocationInfo> e : uploadTableLocations.entrySet()) {
+                        StringBuilder sb = new StringBuilder();
+                        sb.append("\ttable: ").append(e.getKey()).append(" -> ");
+                        for (Map.Entry<String,URI> me : e.getValue().map.entrySet()) {
+                            sb.append("\n\t\t").append(me.getKey()).append(": ").append(me.getValue());
+                        }
+                        log.warn(sb.toString());
                     }
                 }
                 if (selectList != null) {

--- a/cadc-tap/src/main/java/ca/nrc/cadc/tap/schema/TableDesc.java
+++ b/cadc-tap/src/main/java/ca/nrc/cadc/tap/schema/TableDesc.java
@@ -72,6 +72,8 @@ package ca.nrc.cadc.tap.schema;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * Descriptor Class to represent a TAP_SCHEMA.tables table.
@@ -96,7 +98,14 @@ public class TableDesc {
      * where the rows are stored temporarily and loaded later by an external
      * process.
      */
-    public transient URI dataLocation;
+    public transient TableLocationInfo dataLocation;
+    
+    public static class TableLocationInfo {
+        // keys are implementation-specific internal communication between the 
+        // UploadManager: storeTable can create an instance to describe where/how
+        // it stored the table if not in the database and ready to query
+        public final Map<String,URI> map = new TreeMap<>();
+    }
     
     public enum TableType {
         TABLE("table"),


### PR DESCRIPTION
this supports storing the original table data (VOTable) as-is, in a different form, and splitting it into multiple files as needed