### PR TITLE
Make maxRows a transient field of QueryRunner

### DIFF
--- a/cadc-tap-server/src/main/java/ca/nrc/cadc/tap/QueryRunner.java
+++ b/cadc-tap-server/src/main/java/ca/nrc/cadc/tap/QueryRunner.java
@@ -142,6 +142,7 @@ public class QueryRunner implements JobRunner {
     public transient List<TapSelectItem> selectList;
     public transient VOTableDocument resultTemplate;
     public transient String internalSQL;
+    public transient Integer maxRows;
     protected final boolean returnHELD;
     
     private final int responseCodeOnUserFail = 400;
@@ -318,7 +319,7 @@ public class QueryRunner implements JobRunner {
             maxRecValidator.setTapSchema(tapSchema);
             maxRecValidator.setJob(job);
             maxRecValidator.setSynchronousMode(syncOutput != null);
-            final Integer maxRows = maxRecValidator.validate();
+            maxRows = maxRecValidator.validate();
 
             log.debug("creating TapQuery implementation...");
             TapQuery query = pfac.getTapQuery();

--- a/cadc-tap-server/src/main/java/ca/nrc/cadc/tap/QueryRunner.java
+++ b/cadc-tap-server/src/main/java/ca/nrc/cadc/tap/QueryRunner.java
@@ -319,7 +319,7 @@ public class QueryRunner implements JobRunner {
             maxRecValidator.setTapSchema(tapSchema);
             maxRecValidator.setJob(job);
             maxRecValidator.setSynchronousMode(syncOutput != null);
-            maxRows = maxRecValidator.validate();
+            this.maxRows = maxRecValidator.validate();
 
             log.debug("creating TapQuery implementation...");
             TapQuery query = pfac.getTapQuery();


### PR DESCRIPTION
### Short Description:

For the new `KafkaJobExecutor` implementation at Rubin, we need to provide the `maxRows` as a parameter to the Kafka event, so that the qserv-bridge service on the other end of the event-bus when reading in the results from QServ will know whether to specify the `OVERFLOW INFO` element in the result VOTable.